### PR TITLE
chore: publish semver docker tags

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -28,6 +28,13 @@ jobs:
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v3
+      tags: |
+        type=schedule
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=semver,pattern={{major}}
+        type=ref,event=branch
+        type=ref,event=pr
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 


### PR DESCRIPTION
This will publish all the semver tags allowing users to select on major, major.minor, or version tags to get updates easier.