### PR TITLE
chore: publish pr container images

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -39,7 +39,6 @@ jobs:
           type=ref,event=pr
 
     - name: Log in to the Container registry
-      if: github.event_name != 'pull_request'
       uses: docker/login-action@v1
       with:
         registry: ${{ env.REGISTRY }}
@@ -50,6 +49,6 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Publish container images for PRs to make testing on remote environments easier.