### PR TITLE
feat: support cloudflare r2 upload backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster as builder
+FROM golang:1.19.2-buster as builder
 
 RUN apt-get update && apt-get install -y ca-certificates
 
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o filecoin-chain-archiver ./cmd/filecoin-chain-archiver
+RUN make all
 
 FROM debian:buster
 


### PR DESCRIPTION
This removes the use of the website redirect option as it's not supported on Cloudflare's R2 service. The website redirect metadata value was only used to store the latest snapshot. However, we were already writing this as the value of the `latest` object. So we now just read this value in the index-resolver service.

Additionally, R2 does not respond with the location and instead simply returns `auto`. With S3 and minio we were taking avtange of this response value as the S3 API can also be a public-facing endpoint to download objects. This is not the case with R2 and the S3-compatible API is not the same endpoint that is used for public download.

To keep things fairly simple we are now providing this endpoint during upload. In the future though we may want to instead configure this on the index-resolver service. This would probably work better with an additional feature of R2 (custom-domains). 