### PR TITLE
wait for lock to be acquired

### DIFF
--- a/cmd/filecoin-chain-archiver/cmds/locker.go
+++ b/cmd/filecoin-chain-archiver/cmds/locker.go
@@ -116,7 +116,7 @@ var cmdService = &cli.Command{
 								err = fmt.Errorf("lock not aquired")
 								return err
 							}
-							time.Sleep(10 * time.Second)
+							time.Sleep(time.Second + time.Until(lock.Expiry))
 						}
 					},
 				},

--- a/cmd/filecoin-chain-archiver/cmds/locker.go
+++ b/cmd/filecoin-chain-archiver/cmds/locker.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-jsonrpc"
-	"github.com/filecoin-project/lotus/cli/util"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 
@@ -87,8 +87,14 @@ var cmdService = &cli.Command{
 				},
 				{
 					Name:  "lock",
-					Usage: "list current locks",
-					Flags: []cli.Flag{},
+					Usage: "acquire a lock",
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:    "wait",
+							Aliases: []string{"w"},
+							Value:   false,
+						},
+					},
 					Action: func(cctx *cli.Context) error {
 						ctx := context.Background()
 
@@ -98,17 +104,20 @@ var cmdService = &cli.Command{
 							return err
 						}
 
-						fmt.Println(cctx.Args().Get(0))
-						fmt.Println(cctx.Args().Get(1))
-
-						lock, err := api.Lock(ctx, cctx.Args().Get(0), cctx.Args().Get(1))
-						if err != nil {
-							return err
+						for {
+							lock, err := api.Lock(ctx, cctx.Args().Get(0), cctx.Args().Get(1))
+							if err != nil {
+								return err
+							}
+							fmt.Printf("peerid:%s, acquired:%t, expiry:%s\n", lock.PeerID, lock.Acquired, lock.Expiry)
+							if lock.Acquired {
+								return nil
+							} else if !lock.Acquired && !cctx.Bool("wait") {
+								err = fmt.Errorf("lock not aquired")
+								return err
+							}
+							time.Sleep(10 * time.Second)
 						}
-
-						fmt.Printf("%s, %T, %s", lock.PeerID, lock.Aquired, lock.Expiry)
-
-						return nil
 					},
 				},
 				{

--- a/pkg/nodelocker/client/nodelocker.go
+++ b/pkg/nodelocker/client/nodelocker.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/filecoin-project/lotus/cli/util"
 	"github.com/filecoin-project/filecoin-chain-archiver/pkg/nodelocker"
 	"github.com/filecoin-project/filecoin-chain-archiver/pkg/nodelocker/api/apiclient"
+	cliutil "github.com/filecoin-project/lotus/cli/util"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyz"
@@ -46,7 +46,7 @@ func (nl *NodeLock) Renew(ctx context.Context) (bool, error) {
 
 	nl.expiry = lock.Expiry
 
-	return lock.Aquired, nil
+	return lock.Acquired, nil
 }
 
 func (nl *NodeLock) Expiry() time.Time {

--- a/pkg/nodelocker/nodelocker.go
+++ b/pkg/nodelocker/nodelocker.go
@@ -12,9 +12,9 @@ import (
 var logger = log.Logger("filecoin-chain-archiver/pkg/nodelocker")
 
 type NodeLock struct {
-	PeerID  string
-	Expiry  time.Time
-	Aquired bool
+	PeerID   string
+	Expiry   time.Time
+	Acquired bool
 }
 
 type nodeLock struct {
@@ -59,9 +59,9 @@ func (snl *NodeLocker) FetchLocks(ctx context.Context) ([]NodeLock, error) {
 	for e := snl.locks.Front(); e != nil; e = e.Next() {
 		lock := e.Value.(nodeLock)
 		locks = append(locks, NodeLock{
-			PeerID:  lock.peerID,
-			Expiry:  lock.expiry,
-			Aquired: true,
+			PeerID:   lock.peerID,
+			Expiry:   lock.expiry,
+			Acquired: true,
 		})
 	}
 
@@ -86,16 +86,16 @@ func (snl *NodeLocker) Lock(ctx context.Context, peerID, secret string) (NodeLoc
 
 				logger.Infow("updated lock", "expiry", lock.expiry, "peer", lock.peerID, "secret", lock.secret)
 				return NodeLock{
-					PeerID:  lock.peerID,
-					Expiry:  lock.expiry,
-					Aquired: true,
+					PeerID:   lock.peerID,
+					Expiry:   lock.expiry,
+					Acquired: true,
 				}, nil
 			} else {
 				logger.Infow("lock failed", "expiry", lock.expiry, "peer", lock.peerID, "secret", lock.secret)
 				return NodeLock{
-					PeerID:  lock.peerID,
-					Expiry:  lock.expiry,
-					Aquired: false,
+					PeerID:   lock.peerID,
+					Expiry:   lock.expiry,
+					Acquired: false,
 				}, nil
 			}
 		}
@@ -112,8 +112,8 @@ func (snl *NodeLocker) Lock(ctx context.Context, peerID, secret string) (NodeLoc
 	snl.locks.PushBack(lock)
 
 	return NodeLock{
-		PeerID:  lock.peerID,
-		Expiry:  lock.expiry,
-		Aquired: true,
+		PeerID:   lock.peerID,
+		Expiry:   lock.expiry,
+		Acquired: true,
 	}, nil
 }


### PR DESCRIPTION
Add a flag to wait until the lock can be acquired.

This is to facilitate lock acquisition in scripts.

This is how it works:

1. create a new lock
```
./filecoin-chain-archiver nodelocker operator lock abc pass
peerid:abc, acquired:true, expiry:2022-11-04 17:39:56.820841486 -0700 PDT
```

2. Using the same secret, you can update the lock, as usual.

```
/filecoin-chain-archiver nodelocker operator lock abc pass
peerid:abc, acquired:true, expiry:2022-11-04 17:40:53.458506528 -0700 PDT
```

3. Using a new secret, encounter an error trying to get the lock. This is new behavior. We get an exit code telling us the lock was not acquired correctly.

```
./filecoin-chain-archiver nodelocker operator lock abc pass2
peerid:abc, acquired:false, expiry:2022-11-04 17:41:52.042761722 -0700 PDT
2022-11-04T17:40:55.100-0700	ERROR	filecoin-chain-archiver	filecoin-chain-archiver/main.go:44	exit	{"error": "lock not aquired"}

echo $?
1

```

4. To make things easier, pass the -w flag. This will wait until the lock is acquired. This will continue until we own the lock.
```
./filecoin-chain-archiver nodelocker operator lock -w abc pass2
peerid:abc, acquired:false, expiry:2022-11-04 17:48:02.350208491 -0700 PDT
peerid:abc, acquired:true, expiry:2022-11-04 17:49:03.357054703 -0700 PDT

echo $?
0
```


