### PR TITLE
stops uploading raw snapshots to R2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.toml
+filecoin-chain-archiver
+token


### PR DESCRIPTION
lotus now support directly importing zstd compressed car files. stop uploading raw snapshots, as they are too big, and no longer needed