### PR TITLE
increase encoding level for smaller files

### DIFF
--- a/cmd/filecoin-chain-archiver/cmds/create.go
+++ b/cmd/filecoin-chain-archiver/cmds/create.go
@@ -29,7 +29,7 @@ import (
 )
 
 func Compress(in io.Reader, out io.Writer) error {
-	enc, err := zstd.NewWriter(out)
+	enc, err := zstd.NewWriter(out, zstd.WithEncoderLevel(7))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the lotus snapshot export stream should still be slower than the increased compression time.

since we encode a stream, this should have neglible effect on the overall snapshot production time, but potentially make the snapshot artifact size much smaller